### PR TITLE
Errors: add more context with common functions

### DIFF
--- a/selvpc/errors.go
+++ b/selvpc/errors.go
@@ -1,5 +1,27 @@
 package selvpc
 
-const (
-	errParseProjectV2QuotasFmt = "got error parsing quotas: %v"
-)
+import "fmt"
+
+func errParseProjectV2Quotas(err error) error {
+	return fmt.Errorf("got error parsing quotas: %s", err)
+}
+
+func errSearchingProjectRole(projectID string, err error) error {
+	return fmt.Errorf("can't find role for project '%s': %s", projectID, err)
+}
+
+func errCreatingObject(object string, err error) error {
+	return fmt.Errorf("[DEBUG] error creating %s: %s", object, err)
+}
+
+func errUpdatingObject(object, id string, err error) error {
+	return fmt.Errorf("[DEBUG] error updating %s '%s': %s", object, id, err)
+}
+
+func errGettingObject(object, id string, err error) error {
+	return fmt.Errorf("[DEBUG] error getting %s '%s': %s", object, id, err)
+}
+
+func errDeletingObject(object, id string, err error) error {
+	return fmt.Errorf("[DEBUG] error deleting %s '%s': %s", object, id, err)
+}

--- a/selvpc/errors_test.go
+++ b/selvpc/errors_test.go
@@ -1,0 +1,78 @@
+package selvpc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const errString = "got 503"
+
+func TestErrParseProjectV2Quotas(t *testing.T) {
+	err := errors.New(errString)
+
+	expected := errors.New("got error parsing quotas: got 503")
+
+	actual := errParseProjectV2Quotas(err)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestErrSearchingProjectRole(t *testing.T) {
+	projectID := "uuid"
+	err := errors.New(errString)
+
+	expected := errors.New("can't find role for project 'uuid': got 503")
+
+	actual := errSearchingProjectRole(projectID, err)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestErrCreatingObject(t *testing.T) {
+	object := "some stuff"
+	err := errors.New(errString)
+
+	expected := errors.New("[DEBUG] error creating some stuff: got 503")
+
+	actual := errCreatingObject(object, err)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestErrUpdatingObject(t *testing.T) {
+	object := "license"
+	licenseID := "aaa"
+	err := errors.New(errString)
+
+	expected := errors.New("[DEBUG] error updating license 'aaa': got 503")
+
+	actual := errUpdatingObject(object, licenseID, err)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestErrGettingObject(t *testing.T) {
+	object := "project"
+	projectID := "project_1"
+	err := errors.New(errString)
+
+	expected := errors.New("[DEBUG] error getting project 'project_1': got 503")
+
+	actual := errGettingObject(object, projectID, err)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestErrDeletingObject(t *testing.T) {
+	object := "user"
+	projectID := "some_user"
+	err := errors.New(errString)
+
+	expected := errors.New("[DEBUG] error deleting user 'some_user': got 503")
+
+	actual := errDeletingObject(object, projectID, err)
+
+	assert.Equal(t, expected, actual)
+}

--- a/selvpc/resource_selvpc_resell_floatingip_v2.go
+++ b/selvpc/resource_selvpc_resell_floatingip_v2.go
@@ -85,10 +85,10 @@ func resourceResellFloatingIPV2Create(d *schema.ResourceData, meta interface{}) 
 		},
 	}
 
-	log.Printf("[DEBUG] Creating floating ip with options: %v\n", opts)
+	log.Printf("[DEBUG] Creating floating IP with options: %v\n", opts)
 	floatingIPs, _, err := floatingips.Create(ctx, resellV2Client, projectID, opts)
 	if err != nil {
-		return err
+		return errCreatingObject("floating IP", err)
 	}
 
 	if len(floatingIPs) != 1 {
@@ -105,7 +105,7 @@ func resourceResellFloatingIPV2Read(d *schema.ResourceData, meta interface{}) er
 	resellV2Client := config.resellV2Client()
 	ctx := context.Background()
 
-	log.Printf("[DEBUG] Getting floating ip %s", d.Id())
+	log.Printf("[DEBUG] Getting floating IP %s", d.Id())
 	floatingIP, response, err := floatingips.Get(ctx, resellV2Client, d.Id())
 	if err != nil {
 		if response.StatusCode == http.StatusNotFound {
@@ -113,7 +113,7 @@ func resourceResellFloatingIPV2Read(d *schema.ResourceData, meta interface{}) er
 			return nil
 		}
 
-		return err
+		return errGettingObject("floating IP", d.Id(), err)
 	}
 
 	d.Set("fixed_ip_address", floatingIP.FixedIPAddress)
@@ -136,7 +136,7 @@ func resourceResellFloatingIPV2Delete(d *schema.ResourceData, meta interface{}) 
 	resellV2Client := config.resellV2Client()
 	ctx := context.Background()
 
-	log.Printf("[DEBUG] Deleting floating ip %s\n", d.Id())
+	log.Printf("[DEBUG] Deleting floating IP %s\n", d.Id())
 	response, err := floatingips.Delete(ctx, resellV2Client, d.Id())
 	if err != nil {
 		if response.StatusCode == http.StatusNotFound {
@@ -144,7 +144,7 @@ func resourceResellFloatingIPV2Delete(d *schema.ResourceData, meta interface{}) 
 			return nil
 		}
 
-		return err
+		return errDeletingObject("floating IP", d.Id(), err)
 	}
 
 	return nil

--- a/selvpc/resource_selvpc_resell_license_v2.go
+++ b/selvpc/resource_selvpc_resell_license_v2.go
@@ -85,7 +85,7 @@ func resourceResellLicenseV2Create(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[DEBUG] Creating license with options: %v\n", opts)
 	newLicenses, _, err := licenses.Create(ctx, resellV2Client, projectID, opts)
 	if err != nil {
-		return err
+		return errCreatingObject("license", err)
 	}
 
 	if len(newLicenses) != 1 {
@@ -110,7 +110,7 @@ func resourceResellLicenseV2Read(d *schema.ResourceData, meta interface{}) error
 			return nil
 		}
 
-		return err
+		return errGettingObject("license", d.Id(), err)
 	}
 
 	d.Set("project_id", license.ProjectID)
@@ -138,7 +138,7 @@ func resourceResellLicenseV2Delete(d *schema.ResourceData, meta interface{}) err
 			return nil
 		}
 
-		return err
+		return errDeletingObject("license", d.Id(), err)
 	}
 
 	return nil

--- a/selvpc/resource_selvpc_resell_project_v2.go
+++ b/selvpc/resource_selvpc_resell_project_v2.go
@@ -159,7 +159,7 @@ func resourceResellProjectV2Create(d *schema.ResourceData, meta interface{}) err
 	if quotaSet.Len() != 0 {
 		quotasOpts, err := resourceResellProjectV2QuotasOptsFromSet(quotaSet)
 		if err != nil {
-			return fmt.Errorf(errParseProjectV2QuotasFmt, err)
+			return errParseProjectV2Quotas(err)
 		}
 		opts.Quotas = quotasOpts
 	}
@@ -169,7 +169,7 @@ func resourceResellProjectV2Create(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[DEBUG] Creating project with options: %v\n", opts)
 	project, _, err := projects.Create(ctx, resellV2Client, opts)
 	if err != nil {
-		return err
+		return errCreatingObject("project", err)
 	}
 
 	d.SetId(project.ID)
@@ -190,7 +190,7 @@ func resourceResellProjectV2Read(d *schema.ResourceData, meta interface{}) error
 			return nil
 		}
 
-		return err
+		return errGettingObject("project", d.Id(), err)
 	}
 
 	projectCustomURL, err := resourceResellProjectV2URLWithoutSchema(project.CustomURL)
@@ -244,7 +244,7 @@ func resourceResellProjectV2Update(d *schema.ResourceData, meta interface{}) err
 		quotaSet := d.Get("quotas").(*schema.Set)
 		quotasOpts, err := resourceResellProjectV2QuotasOptsFromSet(quotaSet)
 		if err != nil {
-			return fmt.Errorf(errParseProjectV2QuotasFmt, err)
+			return errParseProjectV2Quotas(err)
 		}
 		projectQuotasOpts.QuotasOpts = quotasOpts
 	}
@@ -255,7 +255,7 @@ func resourceResellProjectV2Update(d *schema.ResourceData, meta interface{}) err
 			log.Printf("[DEBUG] Updating project %s with options: %v\n", d.Id(), projectOpts)
 			_, _, err := projects.Update(ctx, resellV2Client, d.Id(), projectOpts)
 			if err != nil {
-				return err
+				return fmt.Errorf("error updating project '%s': %s", d.Id(), err)
 			}
 		}
 		// Update project quotas if needed.
@@ -263,7 +263,7 @@ func resourceResellProjectV2Update(d *schema.ResourceData, meta interface{}) err
 			log.Printf("[DEBUG] Updating project %s quotas with options: %v\n", d.Id(), projectQuotasOpts)
 			_, _, err := quotas.UpdateProjectQuotas(ctx, resellV2Client, d.Id(), projectQuotasOpts)
 			if err != nil {
-				return err
+				return fmt.Errorf("error updating quotas for project '%s': %s", d.Id(), err)
 			}
 		}
 	}
@@ -284,7 +284,7 @@ func resourceResellProjectV2Delete(d *schema.ResourceData, meta interface{}) err
 			return nil
 		}
 
-		return err
+		return errDeletingObject("project", d.Id(), err)
 	}
 
 	return nil

--- a/selvpc/resource_selvpc_resell_role_v2.go
+++ b/selvpc/resource_selvpc_resell_role_v2.go
@@ -47,7 +47,7 @@ func resourceResellRoleV2Create(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[DEBUG] Creating role with options: %v\n", opts)
 	role, _, err := roles.Create(ctx, resellV2Client, opts)
 	if err != nil {
-		return err
+		return errCreatingObject("role", err)
 	}
 
 	d.SetId(resourceResellRoleV2BuildID(role.ProjectID, role.UserID))
@@ -67,7 +67,7 @@ func resourceResellRoleV2Read(d *schema.ResourceData, meta interface{}) error {
 	}
 	projectRoles, _, err := roles.ListProject(ctx, resellV2Client, projectID)
 	if err != nil {
-		return fmt.Errorf("can't find role for project '%s': %s", projectID, err)
+		return errSearchingProjectRole(projectID, err)
 	}
 
 	found := false
@@ -109,7 +109,7 @@ func resourceResellRoleV2Delete(d *schema.ResourceData, meta interface{}) error 
 			return nil
 		}
 
-		return err
+		return errDeletingObject("role", d.Id(), err)
 	}
 
 	return nil

--- a/selvpc/resource_selvpc_resell_role_v2_test.go
+++ b/selvpc/resource_selvpc_resell_role_v2_test.go
@@ -89,7 +89,7 @@ func testAccCheckResellV2RoleExists(n string, role *roles.Role) resource.TestChe
 		}
 		projectRoles, _, err := roles.ListProject(ctx, resellV2Client, projectID)
 		if err != nil {
-			return fmt.Errorf("can't find role for project '%s': %s", projectID, err)
+			return errSearchingProjectRole(projectID, err)
 		}
 
 		found := false

--- a/selvpc/resource_selvpc_resell_subnet_v2.go
+++ b/selvpc/resource_selvpc_resell_subnet_v2.go
@@ -112,7 +112,7 @@ func resourceResellSubnetV2Create(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[DEBUG] Creating subnet with options: %v\n", opts)
 	subnetsResponse, _, err := subnets.Create(ctx, resellV2Client, projectID, opts)
 	if err != nil {
-		return err
+		return errCreatingObject("subnet", err)
 	}
 
 	if len(subnetsResponse) != 1 {
@@ -137,7 +137,7 @@ func resourceResellSubnetV2Read(d *schema.ResourceData, meta interface{}) error 
 			return nil
 		}
 
-		return err
+		return errGettingObject("subnet", d.Id(), err)
 	}
 
 	d.Set("cidr", subnet.CIDR)
@@ -177,7 +177,7 @@ func resourceResellSubnetV2Delete(d *schema.ResourceData, meta interface{}) erro
 			return nil
 		}
 
-		return err
+		return errDeletingObject("subnet", d.Id(), err)
 	}
 
 	return nil

--- a/selvpc/resource_selvpc_resell_user_v2.go
+++ b/selvpc/resource_selvpc_resell_user_v2.go
@@ -49,7 +49,7 @@ func resourceResellUserV2Create(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[DEBUG] Creating user with options: %v\n", opts)
 	user, _, err := users.Create(ctx, resellV2Client, opts)
 	if err != nil {
-		return err
+		return errCreatingObject("user", err)
 	}
 
 	d.SetId(user.ID)
@@ -101,7 +101,7 @@ func resourceResellUserV2Delete(d *schema.ResourceData, meta interface{}) error 
 			return nil
 		}
 
-		return err
+		return errDeletingObject("user", d.Id(), err)
 	}
 
 	return nil


### PR DESCRIPTION
Add helper errors functions in errors.go that can be used to provide
more sense into error messages.

For #17 