### PR TITLE
Config: simplify client initialization, use tuned HTTP timeouts.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -571,7 +571,6 @@
     "github.com/hashicorp/terraform/helper/resource",
     "github.com/hashicorp/terraform/helper/schema",
     "github.com/hashicorp/terraform/helper/validation",
-    "github.com/hashicorp/terraform/httpclient",
     "github.com/hashicorp/terraform/plugin",
     "github.com/hashicorp/terraform/terraform",
     "github.com/selectel/go-selvpcclient/selvpcclient",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -391,7 +391,7 @@
   version = "v1.1.2"
 
 [[projects]]
-  digest = "1:050630e163e7ddb8f4f0644a042a7368644e8c8b2bd79139a62a530f14eb63cf"
+  digest = "1:52fc55b304a1450078dbf7f7f209b62aae80a264e163332771c13e972a160752"
   name = "github.com/selectel/go-selvpcclient"
   packages = [
     "selvpcclient",
@@ -408,8 +408,8 @@
     "selvpcclient/resell/v2/users",
   ]
   pruneopts = "UT"
-  revision = "7b020f257892077543143c9c77cb432af5fcc71a"
-  version = "v1.4.0"
+  revision = "300c0ca2cf0b2798a840b708a7a5f6bfa20d7cb3"
+  version = "v1.5.0"
 
 [[projects]]
   digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"

--- a/selvpc/config.go
+++ b/selvpc/config.go
@@ -2,13 +2,11 @@ package selvpc
 
 import (
 	"errors"
-	"net/http"
 	"strings"
 
-	"github.com/hashicorp/terraform/httpclient"
 	"github.com/selectel/go-selvpcclient/selvpcclient"
 	"github.com/selectel/go-selvpcclient/selvpcclient/resell"
-	resellv2 "github.com/selectel/go-selvpcclient/selvpcclient/resell/v2"
+	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2"
 )
 
 // Config contains all available configuration options.
@@ -23,19 +21,11 @@ func (c *Config) Validate() error {
 		return errors.New("token must be specified")
 	}
 	if c.Endpoint == "" {
-		c.Endpoint = selvpcclient.DefaultEndpoint
+		c.Endpoint = strings.Join([]string{resell.Endpoint, v2.APIVersion}, "/")
 	}
 	return nil
 }
 
 func (c *Config) resellV2Client() *selvpcclient.ServiceClient {
-	endpoint := strings.Join([]string{c.Endpoint, resell.ServiceType, resellv2.APIVersion},
-		"/")
-	resellV2Client := &selvpcclient.ServiceClient{
-		HTTPClient: &http.Client{},
-		Endpoint:   endpoint,
-		TokenID:    c.Token,
-		UserAgent:  httpclient.UserAgentString(),
-	}
-	return resellV2Client
+	return v2.NewV2ResellClientWithEndpoint(c.Token, c.Endpoint)
 }

--- a/selvpc/config_test.go
+++ b/selvpc/config_test.go
@@ -1,0 +1,27 @@
+package selvpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidate(t *testing.T) {
+	config := &Config{
+		Token: "secret",
+	}
+
+	err := config.Validate()
+
+	assert.NoError(t, err)
+}
+
+func TestValidateNoToken(t *testing.T) {
+	config := &Config{}
+
+	expected := "token must be specified"
+
+	actual := config.Validate()
+
+	assert.EqualError(t, actual, expected)
+}

--- a/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/client.go
+++ b/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/client.go
@@ -1,31 +1,29 @@
 package v2
 
 import (
-	"net/http"
-
 	"github.com/selectel/go-selvpcclient/selvpcclient"
 	"github.com/selectel/go-selvpcclient/selvpcclient/resell"
 )
 
 // APIVersion sets the version of the Resell client.
-const APIVersion = "v2"
+const (
+	APIVersion = "v2"
+)
 
 // NewV2ResellClient initializes a new Resell client for the V2 API.
 func NewV2ResellClient(tokenID string) *selvpcclient.ServiceClient {
-	resellClient := &selvpcclient.ServiceClient{
-		HTTPClient: &http.Client{},
+	return &selvpcclient.ServiceClient{
+		HTTPClient: selvpcclient.NewHTTPClient(),
 		Endpoint:   resell.Endpoint + "/" + APIVersion,
 		TokenID:    tokenID,
 		UserAgent:  resell.UserAgent,
 	}
-
-	return resellClient
 }
 
 // NewV2ResellClientWithEndpoint initializes a new Resell client for the V2 API with a custom endpoint.
 func NewV2ResellClientWithEndpoint(tokenID, endpoint string) *selvpcclient.ServiceClient {
 	resellClient := &selvpcclient.ServiceClient{
-		HTTPClient: &http.Client{},
+		HTTPClient: selvpcclient.NewHTTPClient(),
 		Endpoint:   endpoint,
 		TokenID:    tokenID,
 		UserAgent:  resell.UserAgent,

--- a/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/quotas/schemas.go
+++ b/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/quotas/schemas.go
@@ -141,7 +141,7 @@ func (result *ProjectsQuotas) UnmarshalJSON(b []byte) error {
 	if len(s.ProjectsQuotas) != 0 {
 		// Convert projects quota maps to the slice of ProjectQuota types.
 		// Here we're allocating memory in advance for both of project and resource quotas
-		// because we already know the lenght of each slices from the JSON bytearray.
+		// because we already know the length of each slices from the JSON bytearray.
 		projectQuotasSlice := make([]*ProjectQuota, len(s.ProjectsQuotas))
 		i := 0
 		for projectName, projectQuotas := range s.ProjectsQuotas {


### PR DESCRIPTION
Use NewV2ResellClientWithEndpoint() function from the "go-selvpcclient" package.
Add basic unit tests.
Use latest "go-selvpcclient" with tuned HTTP timeouts.

For #14 