### PR TITLE
Resell V2 Cross-region subnets: use lower-case

### DIFF
--- a/selvpc/provider.go
+++ b/selvpc/provider.go
@@ -16,7 +16,7 @@ const (
 	objectToken             = "token"
 	objectUser              = "user"
 	objectVRRPSubnet        = "VRRP subnet"
-	objectCrossRegionSubnet = "Cross-region subnet"
+	objectCrossRegionSubnet = "cross-region subnet"
 )
 
 // Provider returns the selvpc terraform provider.

--- a/selvpc/resource_selvpc_resell_crossregion_subnet_v2_test.go
+++ b/selvpc/resource_selvpc_resell_crossregion_subnet_v2_test.go
@@ -82,7 +82,7 @@ func testAccCheckResellV2CrossRegionSubnetExists(n string, crossRegionSubnet *cr
 		}
 
 		if strconv.Itoa(foundCrossRegionSubnet.ID) != rs.Primary.ID {
-			return errors.New("Cross-region subnet not found")
+			return errors.New("cross-region subnet not found")
 		}
 
 		*crossRegionSubnet = *foundCrossRegionSubnet


### PR DESCRIPTION
Use lower-case for resource name.